### PR TITLE
Fix csvtoqxf service port mismatch

### DIFF
--- a/k3s/csvtoqxf/service.yml
+++ b/k3s/csvtoqxf/service.yml
@@ -10,6 +10,6 @@ spec:
     app: csvtoqxf
   ports:
     - protocol: TCP
-      port: 8314       # Service port
-      targetPort: 5000 # Container port
+      port: 80      # Service port
+      targetPort: 80 # Matches containerPort
       name: csvtoqxf


### PR DESCRIPTION
## Summary
- fix port mapping in `csvtoqxf` service

## Testing
- `kubectl` not available
- `pip install` failed: `pyyaml`

------
https://chatgpt.com/codex/tasks/task_e_684acc2de74c8330a0d37a28eb102a9d